### PR TITLE
Update on way we used task tables in the past; coding in how we build the states and site locations

### DIFF
--- a/frame_tasks.yml
+++ b/frame_tasks.yml
@@ -1,6 +1,6 @@
 # Do not edit - automatically generated
 # from the task_makefile.mustache template
-# by create_task_makefile() via eval()
+# by create_task_makefile() via create_gif_frames()
 # using scipiper package version 0.0.20
 
 target_default: frame_tasks
@@ -11,418 +11,661 @@ include:
 packages:
   - scipiper
 
+sources:
+  - src/data_utils.R
+
 file_extensions:
   - "ind"
 
 targets:
   frame_tasks:
     depends:
-      - gage_age.gif_promise
+      - hash_table
+
+  # --- 1900 --- #
+  
+  twitter/gage_age_1900.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1900)
+
+  # --- 1901 --- #
+  
+  twitter/gage_age_1901.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1901)
+
+  # --- 1902 --- #
+  
+  twitter/gage_age_1902.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1902)
+
+  # --- 1903 --- #
+  
+  twitter/gage_age_1903.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1903)
+
+  # --- 1904 --- #
+  
+  twitter/gage_age_1904.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1904)
+
+  # --- 1905 --- #
+  
+  twitter/gage_age_1905.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1905)
+
+  # --- 1906 --- #
+  
+  twitter/gage_age_1906.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1906)
+
+  # --- 1907 --- #
+  
+  twitter/gage_age_1907.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1907)
+
+  # --- 1908 --- #
+  
+  twitter/gage_age_1908.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1908)
+
+  # --- 1909 --- #
+  
+  twitter/gage_age_1909.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1909)
+
+  # --- 1910 --- #
+  
+  twitter/gage_age_1910.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1910)
+
+  # --- 1911 --- #
+  
+  twitter/gage_age_1911.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1911)
+
+  # --- 1912 --- #
+  
+  twitter/gage_age_1912.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1912)
+
+  # --- 1913 --- #
+  
+  twitter/gage_age_1913.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1913)
+
+  # --- 1914 --- #
+  
+  twitter/gage_age_1914.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1914)
+
+  # --- 1915 --- #
+  
+  twitter/gage_age_1915.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1915)
+
+  # --- 1916 --- #
+  
+  twitter/gage_age_1916.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1916)
+
+  # --- 1917 --- #
+  
+  twitter/gage_age_1917.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1917)
+
+  # --- 1918 --- #
+  
+  twitter/gage_age_1918.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1918)
+
+  # --- 1919 --- #
+  
+  twitter/gage_age_1919.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1919)
+
+  # --- 1920 --- #
+  
+  twitter/gage_age_1920.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1920)
+
+  # --- 1921 --- #
+  
+  twitter/gage_age_1921.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1921)
+
+  # --- 1922 --- #
+  
+  twitter/gage_age_1922.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1922)
+
+  # --- 1923 --- #
+  
+  twitter/gage_age_1923.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1923)
+
+  # --- 1924 --- #
+  
+  twitter/gage_age_1924.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1924)
+
+  # --- 1925 --- #
+  
+  twitter/gage_age_1925.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1925)
+
+  # --- 1926 --- #
+  
+  twitter/gage_age_1926.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1926)
+
+  # --- 1927 --- #
+  
+  twitter/gage_age_1927.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1927)
+
+  # --- 1928 --- #
+  
+  twitter/gage_age_1928.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1928)
+
+  # --- 1929 --- #
+  
+  twitter/gage_age_1929.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1929)
+
+  # --- 1930 --- #
+  
+  twitter/gage_age_1930.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1930)
+
+  # --- 1931 --- #
+  
+  twitter/gage_age_1931.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1931)
+
+  # --- 1932 --- #
+  
+  twitter/gage_age_1932.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1932)
+
+  # --- 1933 --- #
+  
+  twitter/gage_age_1933.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1933)
+
+  # --- 1934 --- #
+  
+  twitter/gage_age_1934.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1934)
+
+  # --- 1935 --- #
+  
+  twitter/gage_age_1935.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1935)
+
+  # --- 1936 --- #
+  
+  twitter/gage_age_1936.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1936)
+
+  # --- 1937 --- #
+  
+  twitter/gage_age_1937.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1937)
+
+  # --- 1938 --- #
+  
+  twitter/gage_age_1938.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1938)
+
+  # --- 1939 --- #
+  
+  twitter/gage_age_1939.png:
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1939)
 
   # --- 1940 --- #
   
   twitter/gage_age_1940.png:
-    command: plot_sites(target_name, gage_melt, yr = 1940)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1940)
 
   # --- 1941 --- #
   
   twitter/gage_age_1941.png:
-    command: plot_sites(target_name, gage_melt, yr = 1941)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1941)
 
   # --- 1942 --- #
   
   twitter/gage_age_1942.png:
-    command: plot_sites(target_name, gage_melt, yr = 1942)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1942)
 
   # --- 1943 --- #
   
   twitter/gage_age_1943.png:
-    command: plot_sites(target_name, gage_melt, yr = 1943)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1943)
 
   # --- 1944 --- #
   
   twitter/gage_age_1944.png:
-    command: plot_sites(target_name, gage_melt, yr = 1944)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1944)
 
   # --- 1945 --- #
   
   twitter/gage_age_1945.png:
-    command: plot_sites(target_name, gage_melt, yr = 1945)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1945)
 
   # --- 1946 --- #
   
   twitter/gage_age_1946.png:
-    command: plot_sites(target_name, gage_melt, yr = 1946)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1946)
 
   # --- 1947 --- #
   
   twitter/gage_age_1947.png:
-    command: plot_sites(target_name, gage_melt, yr = 1947)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1947)
 
   # --- 1948 --- #
   
   twitter/gage_age_1948.png:
-    command: plot_sites(target_name, gage_melt, yr = 1948)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1948)
 
   # --- 1949 --- #
   
   twitter/gage_age_1949.png:
-    command: plot_sites(target_name, gage_melt, yr = 1949)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1949)
 
   # --- 1950 --- #
   
   twitter/gage_age_1950.png:
-    command: plot_sites(target_name, gage_melt, yr = 1950)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1950)
 
   # --- 1951 --- #
   
   twitter/gage_age_1951.png:
-    command: plot_sites(target_name, gage_melt, yr = 1951)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1951)
 
   # --- 1952 --- #
   
   twitter/gage_age_1952.png:
-    command: plot_sites(target_name, gage_melt, yr = 1952)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1952)
 
   # --- 1953 --- #
   
   twitter/gage_age_1953.png:
-    command: plot_sites(target_name, gage_melt, yr = 1953)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1953)
 
   # --- 1954 --- #
   
   twitter/gage_age_1954.png:
-    command: plot_sites(target_name, gage_melt, yr = 1954)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1954)
 
   # --- 1955 --- #
   
   twitter/gage_age_1955.png:
-    command: plot_sites(target_name, gage_melt, yr = 1955)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1955)
 
   # --- 1956 --- #
   
   twitter/gage_age_1956.png:
-    command: plot_sites(target_name, gage_melt, yr = 1956)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1956)
 
   # --- 1957 --- #
   
   twitter/gage_age_1957.png:
-    command: plot_sites(target_name, gage_melt, yr = 1957)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1957)
 
   # --- 1958 --- #
   
   twitter/gage_age_1958.png:
-    command: plot_sites(target_name, gage_melt, yr = 1958)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1958)
 
   # --- 1959 --- #
   
   twitter/gage_age_1959.png:
-    command: plot_sites(target_name, gage_melt, yr = 1959)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1959)
 
   # --- 1960 --- #
   
   twitter/gage_age_1960.png:
-    command: plot_sites(target_name, gage_melt, yr = 1960)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1960)
 
   # --- 1961 --- #
   
   twitter/gage_age_1961.png:
-    command: plot_sites(target_name, gage_melt, yr = 1961)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1961)
 
   # --- 1962 --- #
   
   twitter/gage_age_1962.png:
-    command: plot_sites(target_name, gage_melt, yr = 1962)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1962)
 
   # --- 1963 --- #
   
   twitter/gage_age_1963.png:
-    command: plot_sites(target_name, gage_melt, yr = 1963)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1963)
 
   # --- 1964 --- #
   
   twitter/gage_age_1964.png:
-    command: plot_sites(target_name, gage_melt, yr = 1964)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1964)
 
   # --- 1965 --- #
   
   twitter/gage_age_1965.png:
-    command: plot_sites(target_name, gage_melt, yr = 1965)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1965)
 
   # --- 1966 --- #
   
   twitter/gage_age_1966.png:
-    command: plot_sites(target_name, gage_melt, yr = 1966)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1966)
 
   # --- 1967 --- #
   
   twitter/gage_age_1967.png:
-    command: plot_sites(target_name, gage_melt, yr = 1967)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1967)
 
   # --- 1968 --- #
   
   twitter/gage_age_1968.png:
-    command: plot_sites(target_name, gage_melt, yr = 1968)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1968)
 
   # --- 1969 --- #
   
   twitter/gage_age_1969.png:
-    command: plot_sites(target_name, gage_melt, yr = 1969)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1969)
 
   # --- 1970 --- #
   
   twitter/gage_age_1970.png:
-    command: plot_sites(target_name, gage_melt, yr = 1970)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1970)
 
   # --- 1971 --- #
   
   twitter/gage_age_1971.png:
-    command: plot_sites(target_name, gage_melt, yr = 1971)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1971)
 
   # --- 1972 --- #
   
   twitter/gage_age_1972.png:
-    command: plot_sites(target_name, gage_melt, yr = 1972)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1972)
 
   # --- 1973 --- #
   
   twitter/gage_age_1973.png:
-    command: plot_sites(target_name, gage_melt, yr = 1973)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1973)
 
   # --- 1974 --- #
   
   twitter/gage_age_1974.png:
-    command: plot_sites(target_name, gage_melt, yr = 1974)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1974)
 
   # --- 1975 --- #
   
   twitter/gage_age_1975.png:
-    command: plot_sites(target_name, gage_melt, yr = 1975)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1975)
 
   # --- 1976 --- #
   
   twitter/gage_age_1976.png:
-    command: plot_sites(target_name, gage_melt, yr = 1976)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1976)
 
   # --- 1977 --- #
   
   twitter/gage_age_1977.png:
-    command: plot_sites(target_name, gage_melt, yr = 1977)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1977)
 
   # --- 1978 --- #
   
   twitter/gage_age_1978.png:
-    command: plot_sites(target_name, gage_melt, yr = 1978)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1978)
 
   # --- 1979 --- #
   
   twitter/gage_age_1979.png:
-    command: plot_sites(target_name, gage_melt, yr = 1979)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1979)
 
   # --- 1980 --- #
   
   twitter/gage_age_1980.png:
-    command: plot_sites(target_name, gage_melt, yr = 1980)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1980)
 
   # --- 1981 --- #
   
   twitter/gage_age_1981.png:
-    command: plot_sites(target_name, gage_melt, yr = 1981)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1981)
 
   # --- 1982 --- #
   
   twitter/gage_age_1982.png:
-    command: plot_sites(target_name, gage_melt, yr = 1982)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1982)
 
   # --- 1983 --- #
   
   twitter/gage_age_1983.png:
-    command: plot_sites(target_name, gage_melt, yr = 1983)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1983)
 
   # --- 1984 --- #
   
   twitter/gage_age_1984.png:
-    command: plot_sites(target_name, gage_melt, yr = 1984)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1984)
 
   # --- 1985 --- #
   
   twitter/gage_age_1985.png:
-    command: plot_sites(target_name, gage_melt, yr = 1985)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1985)
 
   # --- 1986 --- #
   
   twitter/gage_age_1986.png:
-    command: plot_sites(target_name, gage_melt, yr = 1986)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1986)
 
   # --- 1987 --- #
   
   twitter/gage_age_1987.png:
-    command: plot_sites(target_name, gage_melt, yr = 1987)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1987)
 
   # --- 1988 --- #
   
   twitter/gage_age_1988.png:
-    command: plot_sites(target_name, gage_melt, yr = 1988)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1988)
 
   # --- 1989 --- #
   
   twitter/gage_age_1989.png:
-    command: plot_sites(target_name, gage_melt, yr = 1989)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1989)
 
   # --- 1990 --- #
   
   twitter/gage_age_1990.png:
-    command: plot_sites(target_name, gage_melt, yr = 1990)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1990)
 
   # --- 1991 --- #
   
   twitter/gage_age_1991.png:
-    command: plot_sites(target_name, gage_melt, yr = 1991)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1991)
 
   # --- 1992 --- #
   
   twitter/gage_age_1992.png:
-    command: plot_sites(target_name, gage_melt, yr = 1992)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1992)
 
   # --- 1993 --- #
   
   twitter/gage_age_1993.png:
-    command: plot_sites(target_name, gage_melt, yr = 1993)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1993)
 
   # --- 1994 --- #
   
   twitter/gage_age_1994.png:
-    command: plot_sites(target_name, gage_melt, yr = 1994)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1994)
 
   # --- 1995 --- #
   
   twitter/gage_age_1995.png:
-    command: plot_sites(target_name, gage_melt, yr = 1995)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1995)
 
   # --- 1996 --- #
   
   twitter/gage_age_1996.png:
-    command: plot_sites(target_name, gage_melt, yr = 1996)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1996)
 
   # --- 1997 --- #
   
   twitter/gage_age_1997.png:
-    command: plot_sites(target_name, gage_melt, yr = 1997)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1997)
 
   # --- 1998 --- #
   
   twitter/gage_age_1998.png:
-    command: plot_sites(target_name, gage_melt, yr = 1998)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1998)
 
   # --- 1999 --- #
   
   twitter/gage_age_1999.png:
-    command: plot_sites(target_name, gage_melt, yr = 1999)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1999)
 
   # --- 2000 --- #
   
   twitter/gage_age_2000.png:
-    command: plot_sites(target_name, gage_melt, yr = 2000)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2000)
 
   # --- 2001 --- #
   
   twitter/gage_age_2001.png:
-    command: plot_sites(target_name, gage_melt, yr = 2001)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2001)
 
   # --- 2002 --- #
   
   twitter/gage_age_2002.png:
-    command: plot_sites(target_name, gage_melt, yr = 2002)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2002)
 
   # --- 2003 --- #
   
   twitter/gage_age_2003.png:
-    command: plot_sites(target_name, gage_melt, yr = 2003)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2003)
 
   # --- 2004 --- #
   
   twitter/gage_age_2004.png:
-    command: plot_sites(target_name, gage_melt, yr = 2004)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2004)
 
   # --- 2005 --- #
   
   twitter/gage_age_2005.png:
-    command: plot_sites(target_name, gage_melt, yr = 2005)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2005)
 
   # --- 2006 --- #
   
   twitter/gage_age_2006.png:
-    command: plot_sites(target_name, gage_melt, yr = 2006)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2006)
 
   # --- 2007 --- #
   
   twitter/gage_age_2007.png:
-    command: plot_sites(target_name, gage_melt, yr = 2007)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2007)
 
   # --- 2008 --- #
   
   twitter/gage_age_2008.png:
-    command: plot_sites(target_name, gage_melt, yr = 2008)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2008)
 
   # --- 2009 --- #
   
   twitter/gage_age_2009.png:
-    command: plot_sites(target_name, gage_melt, yr = 2009)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2009)
 
   # --- 2010 --- #
   
   twitter/gage_age_2010.png:
-    command: plot_sites(target_name, gage_melt, yr = 2010)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2010)
 
   # --- 2011 --- #
   
   twitter/gage_age_2011.png:
-    command: plot_sites(target_name, gage_melt, yr = 2011)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2011)
 
   # --- 2012 --- #
   
   twitter/gage_age_2012.png:
-    command: plot_sites(target_name, gage_melt, yr = 2012)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2012)
 
   # --- 2013 --- #
   
   twitter/gage_age_2013.png:
-    command: plot_sites(target_name, gage_melt, yr = 2013)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2013)
 
   # --- 2014 --- #
   
   twitter/gage_age_2014.png:
-    command: plot_sites(target_name, gage_melt, yr = 2014)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2014)
 
   # --- 2015 --- #
   
   twitter/gage_age_2015.png:
-    command: plot_sites(target_name, gage_melt, yr = 2015)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2015)
 
   # --- 2016 --- #
   
   twitter/gage_age_2016.png:
-    command: plot_sites(target_name, gage_melt, yr = 2016)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2016)
 
   # --- 2017 --- #
   
   twitter/gage_age_2017.png:
-    command: plot_sites(target_name, gage_melt, yr = 2017)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2017)
 
   # --- 2018 --- #
   
   twitter/gage_age_2018.png:
-    command: plot_sites(target_name, gage_melt, yr = 2018)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2018)
 
   # --- 2019 --- #
   
   twitter/gage_age_2019.png:
-    command: plot_sites(target_name, gage_melt, yr = 2019)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2019)
 
   # --- Overall job --- #
 
-  gage_age.gif_promise:
-    command: combine_frames(I('twitter/gage_age.gif'),
+  hash_table:
+    command: tibble_hash_frames(
+      'twitter/gage_age_1900.png',
+      'twitter/gage_age_1901.png',
+      'twitter/gage_age_1902.png',
+      'twitter/gage_age_1903.png',
+      'twitter/gage_age_1904.png',
+      'twitter/gage_age_1905.png',
+      'twitter/gage_age_1906.png',
+      'twitter/gage_age_1907.png',
+      'twitter/gage_age_1908.png',
+      'twitter/gage_age_1909.png',
+      'twitter/gage_age_1910.png',
+      'twitter/gage_age_1911.png',
+      'twitter/gage_age_1912.png',
+      'twitter/gage_age_1913.png',
+      'twitter/gage_age_1914.png',
+      'twitter/gage_age_1915.png',
+      'twitter/gage_age_1916.png',
+      'twitter/gage_age_1917.png',
+      'twitter/gage_age_1918.png',
+      'twitter/gage_age_1919.png',
+      'twitter/gage_age_1920.png',
+      'twitter/gage_age_1921.png',
+      'twitter/gage_age_1922.png',
+      'twitter/gage_age_1923.png',
+      'twitter/gage_age_1924.png',
+      'twitter/gage_age_1925.png',
+      'twitter/gage_age_1926.png',
+      'twitter/gage_age_1927.png',
+      'twitter/gage_age_1928.png',
+      'twitter/gage_age_1929.png',
+      'twitter/gage_age_1930.png',
+      'twitter/gage_age_1931.png',
+      'twitter/gage_age_1932.png',
+      'twitter/gage_age_1933.png',
+      'twitter/gage_age_1934.png',
+      'twitter/gage_age_1935.png',
+      'twitter/gage_age_1936.png',
+      'twitter/gage_age_1937.png',
+      'twitter/gage_age_1938.png',
+      'twitter/gage_age_1939.png',
       'twitter/gage_age_1940.png',
       'twitter/gage_age_1941.png',
       'twitter/gage_age_1942.png',

--- a/frame_tasks.yml
+++ b/frame_tasks.yml
@@ -25,602 +25,602 @@ targets:
   # --- 1900 --- #
   
   twitter/gage_age_1900.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1900)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1900, width = 1024, height = 512)
 
   # --- 1901 --- #
   
   twitter/gage_age_1901.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1901)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1901, width = 1024, height = 512)
 
   # --- 1902 --- #
   
   twitter/gage_age_1902.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1902)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1902, width = 1024, height = 512)
 
   # --- 1903 --- #
   
   twitter/gage_age_1903.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1903)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1903, width = 1024, height = 512)
 
   # --- 1904 --- #
   
   twitter/gage_age_1904.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1904)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1904, width = 1024, height = 512)
 
   # --- 1905 --- #
   
   twitter/gage_age_1905.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1905)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1905, width = 1024, height = 512)
 
   # --- 1906 --- #
   
   twitter/gage_age_1906.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1906)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1906, width = 1024, height = 512)
 
   # --- 1907 --- #
   
   twitter/gage_age_1907.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1907)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1907, width = 1024, height = 512)
 
   # --- 1908 --- #
   
   twitter/gage_age_1908.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1908)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1908, width = 1024, height = 512)
 
   # --- 1909 --- #
   
   twitter/gage_age_1909.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1909)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1909, width = 1024, height = 512)
 
   # --- 1910 --- #
   
   twitter/gage_age_1910.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1910)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1910, width = 1024, height = 512)
 
   # --- 1911 --- #
   
   twitter/gage_age_1911.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1911)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1911, width = 1024, height = 512)
 
   # --- 1912 --- #
   
   twitter/gage_age_1912.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1912)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1912, width = 1024, height = 512)
 
   # --- 1913 --- #
   
   twitter/gage_age_1913.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1913)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1913, width = 1024, height = 512)
 
   # --- 1914 --- #
   
   twitter/gage_age_1914.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1914)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1914, width = 1024, height = 512)
 
   # --- 1915 --- #
   
   twitter/gage_age_1915.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1915)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1915, width = 1024, height = 512)
 
   # --- 1916 --- #
   
   twitter/gage_age_1916.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1916)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1916, width = 1024, height = 512)
 
   # --- 1917 --- #
   
   twitter/gage_age_1917.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1917)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1917, width = 1024, height = 512)
 
   # --- 1918 --- #
   
   twitter/gage_age_1918.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1918)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1918, width = 1024, height = 512)
 
   # --- 1919 --- #
   
   twitter/gage_age_1919.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1919)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1919, width = 1024, height = 512)
 
   # --- 1920 --- #
   
   twitter/gage_age_1920.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1920)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1920, width = 1024, height = 512)
 
   # --- 1921 --- #
   
   twitter/gage_age_1921.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1921)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1921, width = 1024, height = 512)
 
   # --- 1922 --- #
   
   twitter/gage_age_1922.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1922)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1922, width = 1024, height = 512)
 
   # --- 1923 --- #
   
   twitter/gage_age_1923.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1923)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1923, width = 1024, height = 512)
 
   # --- 1924 --- #
   
   twitter/gage_age_1924.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1924)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1924, width = 1024, height = 512)
 
   # --- 1925 --- #
   
   twitter/gage_age_1925.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1925)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1925, width = 1024, height = 512)
 
   # --- 1926 --- #
   
   twitter/gage_age_1926.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1926)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1926, width = 1024, height = 512)
 
   # --- 1927 --- #
   
   twitter/gage_age_1927.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1927)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1927, width = 1024, height = 512)
 
   # --- 1928 --- #
   
   twitter/gage_age_1928.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1928)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1928, width = 1024, height = 512)
 
   # --- 1929 --- #
   
   twitter/gage_age_1929.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1929)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1929, width = 1024, height = 512)
 
   # --- 1930 --- #
   
   twitter/gage_age_1930.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1930)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1930, width = 1024, height = 512)
 
   # --- 1931 --- #
   
   twitter/gage_age_1931.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1931)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1931, width = 1024, height = 512)
 
   # --- 1932 --- #
   
   twitter/gage_age_1932.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1932)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1932, width = 1024, height = 512)
 
   # --- 1933 --- #
   
   twitter/gage_age_1933.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1933)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1933, width = 1024, height = 512)
 
   # --- 1934 --- #
   
   twitter/gage_age_1934.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1934)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1934, width = 1024, height = 512)
 
   # --- 1935 --- #
   
   twitter/gage_age_1935.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1935)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1935, width = 1024, height = 512)
 
   # --- 1936 --- #
   
   twitter/gage_age_1936.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1936)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1936, width = 1024, height = 512)
 
   # --- 1937 --- #
   
   twitter/gage_age_1937.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1937)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1937, width = 1024, height = 512)
 
   # --- 1938 --- #
   
   twitter/gage_age_1938.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1938)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1938, width = 1024, height = 512)
 
   # --- 1939 --- #
   
   twitter/gage_age_1939.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1939)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1939, width = 1024, height = 512)
 
   # --- 1940 --- #
   
   twitter/gage_age_1940.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1940)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1940, width = 1024, height = 512)
 
   # --- 1941 --- #
   
   twitter/gage_age_1941.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1941)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1941, width = 1024, height = 512)
 
   # --- 1942 --- #
   
   twitter/gage_age_1942.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1942)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1942, width = 1024, height = 512)
 
   # --- 1943 --- #
   
   twitter/gage_age_1943.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1943)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1943, width = 1024, height = 512)
 
   # --- 1944 --- #
   
   twitter/gage_age_1944.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1944)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1944, width = 1024, height = 512)
 
   # --- 1945 --- #
   
   twitter/gage_age_1945.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1945)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1945, width = 1024, height = 512)
 
   # --- 1946 --- #
   
   twitter/gage_age_1946.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1946)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1946, width = 1024, height = 512)
 
   # --- 1947 --- #
   
   twitter/gage_age_1947.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1947)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1947, width = 1024, height = 512)
 
   # --- 1948 --- #
   
   twitter/gage_age_1948.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1948)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1948, width = 1024, height = 512)
 
   # --- 1949 --- #
   
   twitter/gage_age_1949.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1949)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1949, width = 1024, height = 512)
 
   # --- 1950 --- #
   
   twitter/gage_age_1950.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1950)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1950, width = 1024, height = 512)
 
   # --- 1951 --- #
   
   twitter/gage_age_1951.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1951)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1951, width = 1024, height = 512)
 
   # --- 1952 --- #
   
   twitter/gage_age_1952.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1952)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1952, width = 1024, height = 512)
 
   # --- 1953 --- #
   
   twitter/gage_age_1953.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1953)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1953, width = 1024, height = 512)
 
   # --- 1954 --- #
   
   twitter/gage_age_1954.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1954)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1954, width = 1024, height = 512)
 
   # --- 1955 --- #
   
   twitter/gage_age_1955.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1955)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1955, width = 1024, height = 512)
 
   # --- 1956 --- #
   
   twitter/gage_age_1956.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1956)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1956, width = 1024, height = 512)
 
   # --- 1957 --- #
   
   twitter/gage_age_1957.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1957)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1957, width = 1024, height = 512)
 
   # --- 1958 --- #
   
   twitter/gage_age_1958.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1958)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1958, width = 1024, height = 512)
 
   # --- 1959 --- #
   
   twitter/gage_age_1959.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1959)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1959, width = 1024, height = 512)
 
   # --- 1960 --- #
   
   twitter/gage_age_1960.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1960)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1960, width = 1024, height = 512)
 
   # --- 1961 --- #
   
   twitter/gage_age_1961.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1961)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1961, width = 1024, height = 512)
 
   # --- 1962 --- #
   
   twitter/gage_age_1962.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1962)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1962, width = 1024, height = 512)
 
   # --- 1963 --- #
   
   twitter/gage_age_1963.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1963)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1963, width = 1024, height = 512)
 
   # --- 1964 --- #
   
   twitter/gage_age_1964.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1964)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1964, width = 1024, height = 512)
 
   # --- 1965 --- #
   
   twitter/gage_age_1965.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1965)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1965, width = 1024, height = 512)
 
   # --- 1966 --- #
   
   twitter/gage_age_1966.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1966)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1966, width = 1024, height = 512)
 
   # --- 1967 --- #
   
   twitter/gage_age_1967.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1967)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1967, width = 1024, height = 512)
 
   # --- 1968 --- #
   
   twitter/gage_age_1968.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1968)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1968, width = 1024, height = 512)
 
   # --- 1969 --- #
   
   twitter/gage_age_1969.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1969)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1969, width = 1024, height = 512)
 
   # --- 1970 --- #
   
   twitter/gage_age_1970.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1970)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1970, width = 1024, height = 512)
 
   # --- 1971 --- #
   
   twitter/gage_age_1971.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1971)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1971, width = 1024, height = 512)
 
   # --- 1972 --- #
   
   twitter/gage_age_1972.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1972)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1972, width = 1024, height = 512)
 
   # --- 1973 --- #
   
   twitter/gage_age_1973.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1973)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1973, width = 1024, height = 512)
 
   # --- 1974 --- #
   
   twitter/gage_age_1974.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1974)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1974, width = 1024, height = 512)
 
   # --- 1975 --- #
   
   twitter/gage_age_1975.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1975)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1975, width = 1024, height = 512)
 
   # --- 1976 --- #
   
   twitter/gage_age_1976.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1976)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1976, width = 1024, height = 512)
 
   # --- 1977 --- #
   
   twitter/gage_age_1977.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1977)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1977, width = 1024, height = 512)
 
   # --- 1978 --- #
   
   twitter/gage_age_1978.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1978)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1978, width = 1024, height = 512)
 
   # --- 1979 --- #
   
   twitter/gage_age_1979.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1979)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1979, width = 1024, height = 512)
 
   # --- 1980 --- #
   
   twitter/gage_age_1980.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1980)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1980, width = 1024, height = 512)
 
   # --- 1981 --- #
   
   twitter/gage_age_1981.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1981)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1981, width = 1024, height = 512)
 
   # --- 1982 --- #
   
   twitter/gage_age_1982.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1982)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1982, width = 1024, height = 512)
 
   # --- 1983 --- #
   
   twitter/gage_age_1983.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1983)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1983, width = 1024, height = 512)
 
   # --- 1984 --- #
   
   twitter/gage_age_1984.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1984)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1984, width = 1024, height = 512)
 
   # --- 1985 --- #
   
   twitter/gage_age_1985.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1985)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1985, width = 1024, height = 512)
 
   # --- 1986 --- #
   
   twitter/gage_age_1986.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1986)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1986, width = 1024, height = 512)
 
   # --- 1987 --- #
   
   twitter/gage_age_1987.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1987)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1987, width = 1024, height = 512)
 
   # --- 1988 --- #
   
   twitter/gage_age_1988.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1988)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1988, width = 1024, height = 512)
 
   # --- 1989 --- #
   
   twitter/gage_age_1989.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1989)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1989, width = 1024, height = 512)
 
   # --- 1990 --- #
   
   twitter/gage_age_1990.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1990)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1990, width = 1024, height = 512)
 
   # --- 1991 --- #
   
   twitter/gage_age_1991.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1991)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1991, width = 1024, height = 512)
 
   # --- 1992 --- #
   
   twitter/gage_age_1992.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1992)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1992, width = 1024, height = 512)
 
   # --- 1993 --- #
   
   twitter/gage_age_1993.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1993)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1993, width = 1024, height = 512)
 
   # --- 1994 --- #
   
   twitter/gage_age_1994.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1994)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1994, width = 1024, height = 512)
 
   # --- 1995 --- #
   
   twitter/gage_age_1995.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1995)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1995, width = 1024, height = 512)
 
   # --- 1996 --- #
   
   twitter/gage_age_1996.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1996)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1996, width = 1024, height = 512)
 
   # --- 1997 --- #
   
   twitter/gage_age_1997.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1997)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1997, width = 1024, height = 512)
 
   # --- 1998 --- #
   
   twitter/gage_age_1998.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1998)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1998, width = 1024, height = 512)
 
   # --- 1999 --- #
   
   twitter/gage_age_1999.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 1999)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 1999, width = 1024, height = 512)
 
   # --- 2000 --- #
   
   twitter/gage_age_2000.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2000)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2000, width = 1024, height = 512)
 
   # --- 2001 --- #
   
   twitter/gage_age_2001.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2001)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2001, width = 1024, height = 512)
 
   # --- 2002 --- #
   
   twitter/gage_age_2002.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2002)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2002, width = 1024, height = 512)
 
   # --- 2003 --- #
   
   twitter/gage_age_2003.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2003)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2003, width = 1024, height = 512)
 
   # --- 2004 --- #
   
   twitter/gage_age_2004.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2004)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2004, width = 1024, height = 512)
 
   # --- 2005 --- #
   
   twitter/gage_age_2005.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2005)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2005, width = 1024, height = 512)
 
   # --- 2006 --- #
   
   twitter/gage_age_2006.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2006)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2006, width = 1024, height = 512)
 
   # --- 2007 --- #
   
   twitter/gage_age_2007.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2007)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2007, width = 1024, height = 512)
 
   # --- 2008 --- #
   
   twitter/gage_age_2008.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2008)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2008, width = 1024, height = 512)
 
   # --- 2009 --- #
   
   twitter/gage_age_2009.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2009)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2009, width = 1024, height = 512)
 
   # --- 2010 --- #
   
   twitter/gage_age_2010.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2010)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2010, width = 1024, height = 512)
 
   # --- 2011 --- #
   
   twitter/gage_age_2011.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2011)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2011, width = 1024, height = 512)
 
   # --- 2012 --- #
   
   twitter/gage_age_2012.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2012)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2012, width = 1024, height = 512)
 
   # --- 2013 --- #
   
   twitter/gage_age_2013.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2013)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2013, width = 1024, height = 512)
 
   # --- 2014 --- #
   
   twitter/gage_age_2014.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2014)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2014, width = 1024, height = 512)
 
   # --- 2015 --- #
   
   twitter/gage_age_2015.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2015)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2015, width = 1024, height = 512)
 
   # --- 2016 --- #
   
   twitter/gage_age_2016.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2016)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2016, width = 1024, height = 512)
 
   # --- 2017 --- #
   
   twitter/gage_age_2017.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2017)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2017, width = 1024, height = 512)
 
   # --- 2018 --- #
   
   twitter/gage_age_2018.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2018)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2018, width = 1024, height = 512)
 
   # --- 2019 --- #
   
   twitter/gage_age_2019.png:
-    command: plot_sites(target_name, gage_melt, state_map = state_map, yr = 2019)
+    command: plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = 2019, width = 1024, height = 512)
 
   # --- Overall job --- #
 

--- a/frame_tasks.yml
+++ b/frame_tasks.yml
@@ -13,6 +13,7 @@ packages:
 
 sources:
   - src/data_utils.R
+  - src/plot_utils.R
 
 file_extensions:
   - "ind"

--- a/remake.yml
+++ b/remake.yml
@@ -51,7 +51,7 @@ targets:
   
   twitter_frames:
     command: create_gif_frames(gage_years, 
-      width = 1024, height = 512, "src/data_utils.R")
+      width = 1024, height = 512, "src/data_utils.R", "src/plot_utils.R")
     depends: [gage_melt, state_map, site_map]
       
       

--- a/remake.yml
+++ b/remake.yml
@@ -8,6 +8,7 @@ packages:
   - rgeos
   - sf
   - patchwork
+  - dataRetrieval
   - scico
   - scipiper
   - remake

--- a/remake.yml
+++ b/remake.yml
@@ -26,14 +26,21 @@ targets:
       - twitter/gage_age.gif
   
   AK:
-    command: list(scale = 0.37, shift = I(c(90,-460)), rotate = I(-50), regions = I("USA:alaska"))
+    command: list(abrv = target_name, scale = 0.37, shift = I(c(90,-460)), 
+      rotate = I(-50), regions = I("USA:alaska"))
   HI:
-    command: list(scale = 1, shift = I(c(520, -110)), rotate = I(-35), regions = I("USA:hawaii"))
+    command: list(abrv = target_name, scale = 1, shift = I(c(520, -110)), 
+      rotate = I(-35), regions = I("USA:hawaii"))
   PR: 
-    command: list(scale = 2.5, shift = I(c(-140, 90)), rotate = 20, regions = I("Puerto Rico"))
+    command: list(abrv = target_name, scale = 2.5, shift = I(c(-140, 90)), 
+      rotate = 20, regions = I("Puerto Rico"))
   
   state_map:
     command: fetch_state_map(AK, HI, PR)
+    
+  site_map:
+    command: shift_sites(AK, HI, PR, 
+      gage_data = "data/active_flow_gages_summary_wy.rds")
       
   gage_melt:
     command: unravel_data(gage_data = "data/active_flow_gages_summary_wy.rds")
@@ -43,7 +50,7 @@ targets:
   
   twitter_frames:
     command: create_gif_frames(gage_years, gage_melt, width = 1024, height = 512, 
-      states = state_map, sites_file = "data/site-map.rds", "src/data_utils.R")
+      states = state_map, sites = site_map, "src/data_utils.R")
       
   twitter/gage_age.gif:
     command: combine_frames(target_name, twitter_frames)

--- a/remake.yml
+++ b/remake.yml
@@ -50,8 +50,10 @@ targets:
     command: seq(I(1900), I(2019))
   
   twitter_frames:
-    command: create_gif_frames(gage_years, gage_melt, width = 1024, height = 512, 
-      states = state_map, sites = site_map, "src/data_utils.R")
+    command: create_gif_frames(gage_years, 
+      width = 1024, height = 512, "src/data_utils.R")
+    depends: [gage_melt, state_map, site_map]
+      
       
   twitter/gage_age.gif:
     command: combine_frames(target_name, twitter_frames)

--- a/remake.yml
+++ b/remake.yml
@@ -4,9 +4,12 @@ packages:
   - tidyverse
   - reshape2
   - sp
+  - maps
+  - rgeos
   - sf
   - patchwork
   - scico
+  - scipiper
   - remake
   - magick
   - showtext
@@ -14,28 +17,33 @@ packages:
 sources:
   - src/data_utils.R
   - src/plot_utils.R
+  - src/task_utils.R
+  - src/map_utils.R
   
 targets:
   gage_age_gif:
     depends:
       - twitter/gage_age.gif
+  
+  AK:
+    command: list(scale = 0.37, shift = I(c(90,-460)), rotate = I(-50), regions = I("USA:alaska"))
+  HI:
+    command: list(scale = 1, shift = I(c(520, -110)), rotate = I(-35), regions = I("USA:hawaii"))
+  PR: 
+    command: list(scale = 2.5, shift = I(c(-140, 90)), rotate = 20, regions = I("Puerto Rico"))
+  
+  state_map:
+    command: fetch_state_map(AK, HI, PR)
       
   gage_melt:
     command: unravel_data(gage_data = "data/active_flow_gages_summary_wy.rds")
     
   gage_years:
-    command: seq(I(1940), I(2019))
-    
-  frame_task_plan:
-    command: create_frame_plan(gage_years, gage_melt)
-    
-  frame_tasks.yml:
-    command: create_task_makefile(
-      task_plan = frame_task_plan, 
-      makefile = target_name, 
-      include = I("remake.yml"),
-      final_targets = I("twitter/gage_age.gif"),
-      finalize_funs = I('combine_frames'))
+    command: seq(I(1900), I(2019))
+  
+  twitter_frames:
+    command: create_gif_frames(gage_years, gage_melt, width = 1024, height = 512, 
+      states = state_map, sites_file = "data/site-map.rds", "src/data_utils.R")
       
   twitter/gage_age.gif:
-    command: scmake(I("gage_age.gif_promise"), remake_file = "frame_tasks.yml")
+    command: combine_frames(target_name, twitter_frames)

--- a/src/map_utils.R
+++ b/src/map_utils.R
@@ -23,17 +23,7 @@ points_sp <- function(locations){
     sp::spTransform(CRS(proj.string)) %>% 
     sp::SpatialPointsDataFrame(data = locations[c('site_no')])
 }
-# 
-# shifts <- list(AK = list(scale = 0.37, shift = c(90,-460), rotate = -50),
-#                HI = list(scale = 1, shift = c(520, -110), rotate = -35),
-#                PR = list(scale = 2.5, shift = c(-140, 90), rotate=20))
-# 
-# stuff_to_move <- list(
-#   AK = to_sp("world", "USA:alaska"),
-#   HI = to_sp("world", "USA:hawaii"),
-#   PR = to_sp("world", "Puerto Rico")
-# )
-# 
+
 
 #' create the sp object 
 #'

--- a/src/map_utils.R
+++ b/src/map_utils.R
@@ -1,0 +1,102 @@
+#' take map arguments and return a projected sp object
+#' 
+#' @param \dots arguments passed to \code{\link[maps]{map}} excluding \code{fill} and \code{plot}
+#' 
+
+proj.string <- "+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 +a=6370997 +b=6370997 +units=m +no_defs"
+to_sp <- function(...){
+  library(maptools)
+  library(maps)
+  map <- maps::map(..., fill=TRUE, plot = FALSE)
+  IDs <- sapply(strsplit(map$names, ":"), function(x) x[1])
+  map.sp <- map2SpatialPolygons(map, IDs=IDs, proj4string=CRS("+proj=longlat +datum=WGS84"))
+  map.sp.t <- spTransform(map.sp, CRS(proj.string))
+  return(map.sp.t)
+}
+
+#' @param locations a data.frame with dec_long_va and dec_lat_va
+points_sp <- function(locations){
+  library(dplyr)
+  
+  points <- cbind(locations$dec_long_va, locations$dec_lat_va) %>% 
+    sp::SpatialPoints(proj4string = CRS("+proj=longlat +datum=WGS84")) %>% 
+    sp::spTransform(CRS(proj.string)) %>% 
+    sp::SpatialPointsDataFrame(data = locations[c('site_no')])
+}
+# 
+# shifts <- list(AK = list(scale = 0.37, shift = c(90,-460), rotate = -50),
+#                HI = list(scale = 1, shift = c(520, -110), rotate = -35),
+#                PR = list(scale = 2.5, shift = c(-140, 90), rotate=20))
+# 
+# stuff_to_move <- list(
+#   AK = to_sp("world", "USA:alaska"),
+#   HI = to_sp("world", "USA:hawaii"),
+#   PR = to_sp("world", "Puerto Rico")
+# )
+# 
+
+#' create the sp object 
+#'
+fetch_state_map <- function(...){
+  shift_details <- list(...)
+  
+  state_map <- to_sp('state')
+  for(i in 1:length(shift_details)){
+    
+    this_sp <- to_sp("world", shift_details[[i]]$regions)
+    these_shifts <- shift_details[[i]][c('scale','shift','rotate')]
+    shifted <- do.call(shift_sp, c(sp = this_sp,
+                                   these_shifts,  
+                                   proj.string = proj4string(state_map),
+                                   row.names = shift_details[[i]]$regions))
+    state_map <- rbind(shifted, state_map, makeUniqueIDs = TRUE)
+  }
+  
+  return(state_map)
+}
+
+process.site_map <- function(...){
+  library(dplyr)
+  sites <- readRDS('cache/disch-sites.rds') %>% filter(!is.na(dec_lat_va))
+  huc.map <- c(AK = "19", HI = "20", PR = "21")
+  
+  #parse huc_cd to 2 digits, and rename to huc to stay consistent
+  sites <- sites %>% mutate(huc = substr(huc, 1,2)) 
+  
+  sites.out <- sites %>% filter(!huc %in% huc.map) %>% 
+    points_sp()
+  
+  for (region in names(huc.map)){
+    sites.tmp <- sites %>% filter(huc %in% huc.map[[region]]) %>% 
+      points_sp()
+    sites.tmp <- do.call(shift_sp, c(sp = sites.tmp, ref = stuff_to_move[[region]], 
+                                     shifts[[region]]))
+    sites.out <- rbind(sites.out, sites.tmp)
+  }
+  saveRDS(sites.out, file = 'cache/site-map.rds')
+}
+
+
+shift_sp <- function(sp, scale = NULL, shift = NULL, rotate = 0, ref=sp, proj.string=NULL, row.names=NULL){
+  if (is.null(scale) & is.null(shift) & rotate == 0){
+    return(obj)
+  }
+  orig.cent <- rgeos::gCentroid(ref, byid=TRUE)@coords
+  scale <- max(apply(bbox(ref), 1, diff)) * scale
+  obj <- elide(sp, rotate=rotate, center=orig.cent, bb = bbox(ref))
+  ref <- elide(ref, rotate=rotate, center=orig.cent, bb = bbox(ref))
+  obj <- elide(obj, scale=scale, center=orig.cent, bb = bbox(ref))
+  ref <- elide(ref, scale=scale, center=orig.cent, bb = bbox(ref))
+  new.cent <- rgeos::gCentroid(ref, byid=TRUE)@coords
+  obj <- elide(obj, shift=shift*10000+c(orig.cent-new.cent))
+  if (is.null(proj.string)){
+    proj4string(obj) <- proj4string(sp)
+  } else {
+    proj4string(obj) <- proj.string
+  }
+  
+  if (!is.null(row.names)){
+    row.names(obj) <- row.names
+  }
+  return(obj)
+}

--- a/src/plot_utils.R
+++ b/src/plot_utils.R
@@ -115,12 +115,11 @@ plot_sites <- function(filename, gage_melt, yr, site_map, state_map, width = 102
 combine_frames <- function(file_out, hash_table){
   
   frame_names <- hash_table$filename
-  
   # display the last frame first
   collapse_frames <- paste(c(tail(frame_names,1), frame_names), collapse = ' ')
   
   system(sprintf('convert %s %s', collapse_frames, file_out))
   reg_frames <- paste(sprintf('"#%s"', 1:(length(frame_names)-1)), collapse = ' ')
-  system(sprintf('gifsicle -b -O3 %s -d0 "#0" -d14 %s -d400 "#%s" --colors 256', file_out, reg_frames, length(frame_names)-1))
+  system(sprintf('gifsicle -b -O3 %s -d0 "#0" -d14 %s -d400 "#%s" --colors 256', file_out, reg_frames, length(frame_names)))
   
 }

--- a/src/plot_utils.R
+++ b/src/plot_utils.R
@@ -1,6 +1,6 @@
 
 # for each year (frame), plot gained gages and the age distribution
-plot_sites <- function(filename, gage_melt, yr, site_data = "data/site-map.rds", state_data ="data/state-map.rds"){
+plot_sites <- function(filename, gage_melt, yr, site_data = "data/site-map.rds", state_map, width = 1024, height = 512){
   
   theme_set(theme_classic(base_size=16))
   showtext_auto()
@@ -11,7 +11,7 @@ plot_sites <- function(filename, gage_melt, yr, site_data = "data/site-map.rds",
   
   # convert to sf 
   sites.sf <- readRDS(site_data) %>% st_as_sf() # all sites
-  states.sf <- readRDS(state_data) %>% st_as_sf()
+  states.sf <- state_map %>% st_as_sf()
   
   # filter gage data to given year
   yr_gages <- gage_melt %>%
@@ -64,7 +64,7 @@ plot_sites <- function(filename, gage_melt, yr, site_data = "data/site-map.rds",
   
   # save plot - stylized to twitter
   ## write to png
-  png(filename = filename, width = 1024, height = 512, units='px')
+  png(filename = filename, units='px')
   ## hacky to set px
   print({ 
     # combine everything
@@ -112,30 +112,15 @@ plot_sites <- function(filename, gage_melt, yr, site_data = "data/site-map.rds",
   
 }
 
-create_frame_plan <- function(gage_years, gage_melt){
-  step1 <- create_task_step(
-    step_name = 'plot',
-    target_name = function(task_name, step_name, ...) {
-      sprintf('twitter/gage_age_%s.png', task_name)
-    },
-    command = function(task_name, step_name, ...) {
-      sprintf('plot_sites(target_name, gage_melt, yr = %s)', task_name)
-    }
-  )
-  task_plan <- create_task_plan(as.character(gage_years), list(step1),
-                                final_steps='plot', add_complete = FALSE)
-  return(task_plan)
-}
-
-combine_frames <- function(filename, ...){
+combine_frames <- function(file_out, hash_table){
   
-  frame_names <- c(...)
+  frame_names <- hash_table$filename
   
   # display the last frame first
   collapse_frames <- paste(c(tail(frame_names,1), frame_names), collapse = ' ')
   
-  system(sprintf('convert %s %s', collapse_frames, filename))
+  system(sprintf('convert %s %s', collapse_frames, file_out))
   reg_frames <- paste(sprintf('"#%s"', 1:(length(frame_names)-1)), collapse = ' ')
-  system(sprintf('gifsicle -b -O3 %s -d0 "#0" -d14 %s -d400 "#%s" --colors 256', filename, reg_frames, length(frame_names)-1))
+  system(sprintf('gifsicle -b -O3 %s -d0 "#0" -d14 %s -d14 "#%s" --colors 256', file_out, reg_frames, length(frame_names)-1))
   
 }

--- a/src/plot_utils.R
+++ b/src/plot_utils.R
@@ -1,6 +1,6 @@
 
 # for each year (frame), plot gained gages and the age distribution
-plot_sites <- function(filename, gage_melt, yr, site_data = "data/site-map.rds", state_map, width = 1024, height = 512){
+plot_sites <- function(filename, gage_melt, yr, site_map, state_map, width = 1024, height = 512){
   
   theme_set(theme_classic(base_size=16))
   showtext_auto()
@@ -10,7 +10,7 @@ plot_sites <- function(filename, gage_melt, yr, site_data = "data/site-map.rds",
   yr_max <- max(gage_melt$years_cum)
   
   # convert to sf 
-  sites.sf <- readRDS(site_data) %>% st_as_sf() # all sites
+  sites.sf <- site_map %>% st_as_sf() # all sites
   states.sf <- state_map %>% st_as_sf()
   
   # filter gage data to given year
@@ -64,7 +64,7 @@ plot_sites <- function(filename, gage_melt, yr, site_data = "data/site-map.rds",
   
   # save plot - stylized to twitter
   ## write to png
-  png(filename = filename, units='px')
+  png(filename = filename, units='px', width = width, height = height)
   ## hacky to set px
   print({ 
     # combine everything

--- a/src/plot_utils.R
+++ b/src/plot_utils.R
@@ -121,6 +121,6 @@ combine_frames <- function(file_out, hash_table){
   
   system(sprintf('convert %s %s', collapse_frames, file_out))
   reg_frames <- paste(sprintf('"#%s"', 1:(length(frame_names)-1)), collapse = ' ')
-  system(sprintf('gifsicle -b -O3 %s -d0 "#0" -d14 %s -d14 "#%s" --colors 256', file_out, reg_frames, length(frame_names)-1))
+  system(sprintf('gifsicle -b -O3 %s -d0 "#0" -d14 %s -d400 "#%s" --colors 256', file_out, reg_frames, length(frame_names)-1))
   
 }

--- a/src/task_utils.R
+++ b/src/task_utils.R
@@ -6,7 +6,7 @@ create_frame_plan <- function(gage_years, gage_melt, width, height){
       sprintf('twitter/gage_age_%s.png', task_name)
     },
     command = function(task_name, step_name, ...) {
-      sprintf('plot_sites(target_name, gage_melt, state_map = state_map, yr = %s, width = %s, height = %s)', task_name, width, height)
+      sprintf('plot_sites(target_name, gage_melt, state_map = state_map, site_map = site_map, yr = %s, width = %s, height = %s)', task_name, width, height)
     }
   )
   task_plan <- create_task_plan(as.character(gage_years), list(step1),
@@ -19,7 +19,7 @@ tibble_hash_frames <- function(...){
   tibble(filename = c(...), hash = tools::md5sum(filename))
 }
 
-create_gif_frames <- function(gage_years, gage_melt, states, sites_file, width, height, ...){
+create_gif_frames <- function(gage_years, gage_melt, states, sites, width, height, ...){
   frame_plan <- create_frame_plan(gage_years, gage_melt, width = width, height = height)
   
   frame_makefile <- "frame_tasks.yml"

--- a/src/task_utils.R
+++ b/src/task_utils.R
@@ -1,0 +1,39 @@
+
+create_frame_plan <- function(gage_years, gage_melt, width, height){
+  step1 <- create_task_step(
+    step_name = 'plot',
+    target_name = function(task_name, step_name, ...) {
+      sprintf('twitter/gage_age_%s.png', task_name)
+    },
+    command = function(task_name, step_name, ...) {
+      sprintf('plot_sites(target_name, gage_melt, state_map = state_map, yr = %s, width = %s, height = %s)', task_name, width, height)
+    }
+  )
+  task_plan <- create_task_plan(as.character(gage_years), list(step1),
+                                final_steps='plot', add_complete = FALSE)
+  return(task_plan)
+}
+
+
+tibble_hash_frames <- function(...){
+  tibble(filename = c(...), hash = tools::md5sum(filename))
+}
+
+create_gif_frames <- function(gage_years, gage_melt, states, sites_file, width, height, ...){
+  frame_plan <- create_frame_plan(gage_years, gage_melt, width = width, height = height)
+  
+  frame_makefile <- "frame_tasks.yml"
+  
+  create_task_makefile(
+    task_plan = frame_plan, 
+    makefile = frame_makefile,
+    sources = c(...),
+    include = "remake.yml",
+    final_targets = 'hash_table',
+    finalize_funs = 'tibble_hash_frames',
+    as_promises = FALSE)
+  
+  hash_table <- scmake('hash_table',  remake_file = "frame_tasks.yml")
+  return(hash_table)
+
+}

--- a/src/task_utils.R
+++ b/src/task_utils.R
@@ -1,5 +1,5 @@
 
-create_frame_plan <- function(gage_years, gage_melt, width, height){
+create_frame_plan <- function(gage_years, width, height){
   step1 <- create_task_step(
     step_name = 'plot',
     target_name = function(task_name, step_name, ...) {
@@ -19,8 +19,8 @@ tibble_hash_frames <- function(...){
   tibble(filename = c(...), hash = tools::md5sum(filename))
 }
 
-create_gif_frames <- function(gage_years, gage_melt, states, sites, width, height, ...){
-  frame_plan <- create_frame_plan(gage_years, gage_melt, width = width, height = height)
+create_gif_frames <- function(gage_years, width, height, ...){
+  frame_plan <- create_frame_plan(gage_years, width = width, height = height)
   
   frame_makefile <- "frame_tasks.yml"
   


### PR DESCRIPTION
I modified the task tables to use something closer to what we had in the pipelines course, instead of this older way we were building tables in the past that was in the gif code repo I pointed you to. This is a more robust way to code it. 

Also, despite the combiners being useful for creating a gif from many frames, I separated that out into a separate target from the hashed files. This could be useful for using different ways to ultimately build the final gif/video. 

I added code that generates the state and site locations, so that those don't need to read in from a file that others won't have. Now the GIF should rely on only one file, which is `active_flow_gages_summary_wy.rds`. We might want to point to the national flow repo (which is where that file comes from) in the comments on the yaml or in the readme for this repo. 

I think the only thing I changed to your plotting code was to go back to 1900 in the plot (was just experimenting with that) and I changed the frame number that is "paused" because it was doing the second to last frame instead of the last. 